### PR TITLE
Added fix to shorten temp file name when on windows which has issues …

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,11 @@ var md5hex = function () {
 }
 var invocations = 0;
 var getTmpname = function (filename) {
-    return filename + "." + md5hex(__filename, process.pid, ++invocations)
+	var isWin = /^win/.test(process.platform)
+	if(isWin){
+		return filename + ".tmp";
+	}
+    return filename + "." + md5hex(__filename, process.pid, ++invocations);
 }
 
 module.exports = function writeFile(filename, data, options, callback) {


### PR DESCRIPTION
…with long file paths.

Adding 33 characters to the end of a file greatly increase the chances of rename errors being thrown in the win32 api.