### PR TITLE
deps: Upgrade graceful-fs dependency to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/iarna/write-file-atomic",
   "dependencies": {
-    "graceful-fs": "^3.0.2",
+    "graceful-fs": "^4.1.2",
     "slide": "^1.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
graceful-fs used to monkey-patch node's core fs module.
This has been fixed in the version 4.

Related: https://github.com/nodejs/node/pull/2714